### PR TITLE
Update build-slackware-15-packages.yml

### DIFF
--- a/.github/workflows/build-slackware-15-packages.yml
+++ b/.github/workflows/build-slackware-15-packages.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
 jobs:
   push_container:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Explicitly sets the contents permissions to allow creating, pushing tags and releases to upstream.